### PR TITLE
BUGFIX: Explicitly check for an array to work in PHP7

### DIFF
--- a/Classes/Portachtzig/Neos/Piwik/Domain/Dto/BrowserDataResult.php
+++ b/Classes/Portachtzig/Neos/Piwik/Domain/Dto/BrowserDataResult.php
@@ -39,7 +39,7 @@ class BrowserDataResult implements \JsonSerializable
         $clientBrowser = array();
         $allBrowser = array();
         foreach ($results as $year => $devices) {
-            if (!empty($devices)) {
+            if (is_array($devices)) {
                 foreach ($devices as $device) {
                     $totalVisits = $totalVisits + $device['nb_visits'];
                 }

--- a/Classes/Portachtzig/Neos/Piwik/Domain/Dto/DeviceDataResult.php
+++ b/Classes/Portachtzig/Neos/Piwik/Domain/Dto/DeviceDataResult.php
@@ -43,7 +43,7 @@ class DeviceDataResult implements \JsonSerializable
         );
 
         foreach ($results as $year => $devices) {
-            if (!empty($devices)) {
+            if (is_array($devices)) {
                 foreach ($devices as $device) {
                     if ($device['label'] == 'Desktop') {
                         $clientDevices['Desktop'] = $clientDevices['Desktop'] + $device['nb_visits'];

--- a/Classes/Portachtzig/Neos/Piwik/Domain/Dto/OperatingSystemDataResult.php
+++ b/Classes/Portachtzig/Neos/Piwik/Domain/Dto/OperatingSystemDataResult.php
@@ -45,7 +45,7 @@ class OperatingSystemDataResult implements \JsonSerializable
         );
 
         foreach ($results as $year => $devices) {
-            if (!empty($devices)) {
+            if (is_array($devices)) {
                 foreach ($devices as $device) {
                     if ($device['label'] == 'GNU/Linux') {
                         $clientOperatingSystems['GNU/Linux'] = $clientOperatingSystems['GNU/Linux'] + $device['nb_visits'];

--- a/Classes/Portachtzig/Neos/Piwik/Domain/Dto/OutlinkDataResult.php
+++ b/Classes/Portachtzig/Neos/Piwik/Domain/Dto/OutlinkDataResult.php
@@ -39,7 +39,7 @@ class OutlinkDataResult implements \JsonSerializable
         $visitedOutlinks = array();
         $allOutlinks = array();
         foreach ($results as $year => $devices) {
-            if (!empty($devices)) {
+            if (is_array($devices)) {
                 foreach ($devices as $device) {
                     $totalVisits = $totalVisits + $device['nb_hits'];
 


### PR DESCRIPTION
In case piwik has no results or the result contains an error, the entries
of the result are no arrays itself. So !empty succeeds but PHP7 throws an
uncaught exception as it is no array to loop over.