### PR TITLE
Fix typo in <noscript> tracking code

### DIFF
--- a/Resources/Private/Templates/Prototypes/TrackingCode.html
+++ b/Resources/Private/Templates/Prototypes/TrackingCode.html
@@ -12,6 +12,6 @@
   })();
 
 </script>
-<noscript><p><img src="//{settings.host}/piwik.php?idSite={settings.idSite}" style="border:0;" alt="" /></p></noscript>
+<noscript><p><img src="//{settings.host}/piwik.php?idsite={settings.idSite}" style="border:0;" alt="" /></p></noscript>
 <!-- End Piwik Code -->
 


### PR DESCRIPTION
The query parameter should be "idsite" (all lowercase). Otherwise, Piwik
throws an error and tracking without JavaScript does not work.

See https://forum.piwik.org/t/getting-invalid-idsite-error/12287