### PR TITLE
Do not show the tracking code with empty or invalid settings

### DIFF
--- a/Resources/Private/TypoScript/Prototypes/TrackingCode.ts2
+++ b/Resources/Private/TypoScript/Prototypes/TrackingCode.ts2
@@ -1,6 +1,13 @@
 # A Piwik tracking code object
 #
 prototype(Portachtzig.Neos.Piwik:TrackingCode) < prototype(TYPO3.TypoScript:Template) {
-	@if.inLiveWorkspace = ${node.context.workspaceName == 'live'}
 	templatePath = 'resource://Portachtzig.Neos.Piwik/Private/Templates/Prototypes/TrackingCode.html'
+	settings = ${Configuration.setting('Portachtzig.Neos.Piwik')}
+
+	// Show tracking code only in live workspace and if all necessary parameters are set
+	@if {
+		inLiveWorkspace = ${node.context.workspaceName == 'live'}
+		hostIsSet = ${settings.host}
+		idSiteIsSet = ${settings.idSite}
+	}
 }

--- a/Resources/Private/TypoScript/Root.ts2
+++ b/Resources/Private/TypoScript/Root.ts2
@@ -4,9 +4,5 @@ prototype(TYPO3.Neos:Page) {
   piwikTrackingCode = Portachtzig.Neos.Piwik:TrackingCode {
     # Google suggests to include the tracking code directly after the <body> tag
     @position = 'end'
-    settings = ${Configuration.setting('Portachtzig.Neos.Piwik')}
-
   }
 }
-
-


### PR DESCRIPTION
The tracking code was displayed even if no idSite or host was configured
in the backend module (or manually in Settings.yaml).

This fixes this by adding two conditions that check if both host and
idSite parameters are set.